### PR TITLE
Fix blank flashcard export

### DIFF
--- a/smartdefine-firefox-extension/src/ui/extension_tabs.js
+++ b/smartdefine-firefox-extension/src/ui/extension_tabs.js
@@ -976,7 +976,7 @@ function generateFlashcardsExport(wordsData, filename) {
 </html>`;
 
   // Open new window with the flashcard content
-  const newWindow = window.open('', '_blank');
+  const newWindow = window.open('about:blank', '_blank');
   newWindow.document.open();
   const parser = new DOMParser();
   const parsedDoc = parser.parseFromString(htmlContent, 'text/html');
@@ -1083,7 +1083,7 @@ function generatePdfExport(wordsData, filename) {
 </html>`;
 
   // Open new window with the content
-  const newWindow = window.open('', '_blank');
+  const newWindow = window.open('about:blank', '_blank');
   newWindow.document.open();
   const parser = new DOMParser();
   const parsedDoc = parser.parseFromString(htmlContent, 'text/html');

--- a/smartdefine-firefox-extension/src/ui/wordlist.js
+++ b/smartdefine-firefox-extension/src/ui/wordlist.js
@@ -500,7 +500,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const htmlContent = generatePDFContent(words);
     
     // Create a new window for PDF printing using safe DOM methods
-    const printWindow = window.open('', '_blank');
+    const printWindow = window.open('about:blank', '_blank');
     const parser = new DOMParser();
     const parsedDoc = parser.parseFromString(htmlContent, 'text/html');
     printWindow.document.replaceChild(
@@ -1128,7 +1128,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   function exportWordToPDF(wordData) {
     const htmlContent = generateSingleWordPDFContent(wordData);
     
-    const printWindow = window.open('', '_blank');
+    const printWindow = window.open('about:blank', '_blank');
     const parser = new DOMParser();
     const parsedDoc = parser.parseFromString(htmlContent, 'text/html');
     printWindow.document.replaceChild(
@@ -1204,7 +1204,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   function exportWordAsFlashcard(wordData) {
     const flashcardContent = generateFlashcardContent(wordData);
     
-    const printWindow = window.open('', '_blank');
+    const printWindow = window.open('about:blank', '_blank');
     const parser = new DOMParser();
     const parsedDoc = parser.parseFromString(flashcardContent, 'text/html');
     printWindow.document.replaceChild(


### PR DESCRIPTION
## Summary
- ensure new windows open on `about:blank` before injecting HTML
- update export functions in `wordlist.js` and `extension_tabs.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68604cea3a888330aa22856eb9bc8892