### PR TITLE
Fix export to flashcards window

### DIFF
--- a/smartdefine-firefox-extension/src/ui/extension_tabs.js
+++ b/smartdefine-firefox-extension/src/ui/extension_tabs.js
@@ -976,15 +976,9 @@ function generateFlashcardsExport(wordsData, filename) {
 </html>`;
 
   // Open new window with the flashcard content
-  const newWindow = window.open('about:blank', '_blank');
-  newWindow.document.open();
-  const parser = new DOMParser();
-  const parsedDoc = parser.parseFromString(htmlContent, 'text/html');
-  newWindow.document.replaceChild(
-    newWindow.document.adoptNode(parsedDoc.documentElement),
-    newWindow.document.documentElement
-  );
-  newWindow.document.close();
+  const dataUrl = 'data:text/html;charset=utf-8,' +
+    encodeURIComponent(htmlContent);
+  window.open(dataUrl, '_blank');
 }
 
 // Generate JSON export
@@ -1083,15 +1077,9 @@ function generatePdfExport(wordsData, filename) {
 </html>`;
 
   // Open new window with the content
-  const newWindow = window.open('about:blank', '_blank');
-  newWindow.document.open();
-  const parser = new DOMParser();
-  const parsedDoc = parser.parseFromString(htmlContent, 'text/html');
-  newWindow.document.replaceChild(
-    newWindow.document.adoptNode(parsedDoc.documentElement),
-    newWindow.document.documentElement
-  );
-  newWindow.document.close();
+  const dataUrl = 'data:text/html;charset=utf-8,' +
+    encodeURIComponent(htmlContent);
+  window.open(dataUrl, '_blank');
 }
 
 // Show add category modal

--- a/smartdefine-firefox-extension/src/ui/wordlist.js
+++ b/smartdefine-firefox-extension/src/ui/wordlist.js
@@ -500,13 +500,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     const htmlContent = generatePDFContent(words);
     
     // Create a new window for PDF printing using safe DOM methods
-    const printWindow = window.open('about:blank', '_blank');
-    const parser = new DOMParser();
-    const parsedDoc = parser.parseFromString(htmlContent, 'text/html');
-    printWindow.document.replaceChild(
-      printWindow.document.adoptNode(parsedDoc.documentElement),
-      printWindow.document.documentElement
-    );
+
+    const dataUrl = 'data:text/html;charset=utf-8,' +
+      encodeURIComponent(htmlContent);
+    const printWindow = window.open(dataUrl, '_blank');
     
     // Trigger print dialog (user can save as PDF)
     printWindow.onload = () => {
@@ -1128,14 +1125,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   function exportWordToPDF(wordData) {
     const htmlContent = generateSingleWordPDFContent(wordData);
     
-    const printWindow = window.open('about:blank', '_blank');
-    const parser = new DOMParser();
-    const parsedDoc = parser.parseFromString(htmlContent, 'text/html');
-    printWindow.document.replaceChild(
-      printWindow.document.adoptNode(parsedDoc.documentElement),
-      printWindow.document.documentElement
-    );
-    
+    const dataUrl = 'data:text/html;charset=utf-8,' +
+      encodeURIComponent(htmlContent);
+    const printWindow = window.open(dataUrl, '_blank');
+
     printWindow.onload = () => {
       printWindow.print();
       setTimeout(() => printWindow.close(), 1000);
@@ -1203,15 +1196,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   function exportWordAsFlashcard(wordData) {
     const flashcardContent = generateFlashcardContent(wordData);
-    
-    const printWindow = window.open('about:blank', '_blank');
-    const parser = new DOMParser();
-    const parsedDoc = parser.parseFromString(flashcardContent, 'text/html');
-    printWindow.document.replaceChild(
-      printWindow.document.adoptNode(parsedDoc.documentElement),
-      printWindow.document.documentElement
-    );
-    
+
+    const dataUrl = 'data:text/html;charset=utf-8,' +
+      encodeURIComponent(flashcardContent);
+    const printWindow = window.open(dataUrl, '_blank');
+
     printWindow.onload = () => {
       printWindow.print();
       setTimeout(() => printWindow.close(), 1000);


### PR DESCRIPTION
## Summary
- open export windows using data URLs so content loads directly

## Testing
- `node --check smartdefine-firefox-extension/src/ui/extension_tabs.js`
- `node --check smartdefine-firefox-extension/src/ui/wordlist.js`


------
https://chatgpt.com/codex/tasks/task_b_6860502766588330ae77a04e6c1fea30