### PR TITLE
Fix flashcard export

### DIFF
--- a/smartdefine-firefox-extension/manifest.json
+++ b/smartdefine-firefox-extension/manifest.json
@@ -15,6 +15,7 @@
     "storage",
     "alarms",
     "notifications",
+    "tabs",
     "<all_urls>"
   ],
   "background": {

--- a/smartdefine-firefox-extension/src/ui/extension_tabs.js
+++ b/smartdefine-firefox-extension/src/ui/extension_tabs.js
@@ -978,7 +978,11 @@ function generateFlashcardsExport(wordsData, filename) {
   // Open new window with the flashcard content
   const dataUrl = 'data:text/html;charset=utf-8,' +
     encodeURIComponent(htmlContent);
-  window.open(dataUrl, '_blank');
+  if (typeof browser !== 'undefined' && browser.tabs && browser.tabs.create) {
+    browser.tabs.create({ url: dataUrl });
+  } else {
+    window.open(dataUrl, '_blank');
+  }
 }
 
 // Generate JSON export


### PR DESCRIPTION
## Summary
- add `tabs` permission
- open flashcards in a new tab via `browser.tabs.create`

## Testing
- `web-ext lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686053a5fe448330b4bf2585663be70c