### PR TITLE
Fix flashcard export

### DIFF
--- a/smartdefine-firefox-extension/manifest.json
+++ b/smartdefine-firefox-extension/manifest.json
@@ -15,6 +15,7 @@
     "storage",
     "alarms",
     "notifications",
+    "tabs",
     "<all_urls>"
   ],
   "background": {

--- a/smartdefine-firefox-extension/src/ui/extension_tabs.js
+++ b/smartdefine-firefox-extension/src/ui/extension_tabs.js
@@ -976,9 +976,19 @@ function generateFlashcardsExport(wordsData, filename) {
 </html>`;
 
   // Open new window with the flashcard content
-  const dataUrl = 'data:text/html;charset=utf-8,' +
-    encodeURIComponent(htmlContent);
-  window.open(dataUrl, '_blank');
+  const blob = new Blob([htmlContent], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+
+  if (typeof browser !== 'undefined' && browser.tabs && browser.tabs.create) {
+    browser.tabs.create({ url }).then(() => {
+      setTimeout(() => URL.revokeObjectURL(url), 10000);
+    });
+  } else {
+    const newWindow = window.open(url, '_blank');
+    if (newWindow) {
+      setTimeout(() => URL.revokeObjectURL(url), 10000);
+    }
+  }
 }
 
 // Generate JSON export


### PR DESCRIPTION
## Summary
- create blob URLs for flashcard export
- revoke object URLs after tab is created

## Testing
- `npx -y web-ext lint -s smartdefine-firefox-extension`

------
https://chatgpt.com/codex/tasks/task_b_686053a5fe448330b4bf2585663be70c