### PR TITLE
Fix provider fallback and add prompt logging

### DIFF
--- a/smartdefine-firefox-extension/src/background/background.js
+++ b/smartdefine-firefox-extension/src/background/background.js
@@ -53,49 +53,61 @@ browser.runtime.onInstalled.addListener(() => {
 });
 
 
-// Function to call different LLM APIs
+// Function to call different LLM APIs with fallback when one fails
 async function callLLMAPI(selectedText, context, settings) {
   const { selectedProvider, prompt, providers } = settings;
-  
-  if (!providers || !providers[selectedProvider]) {
-    throw new Error(`Provider configuration not found: ${selectedProvider}`);
+
+  if (!providers || Object.keys(providers).length === 0) {
+    throw new Error('Provider configuration not found');
   }
-  
-  const providerConfig = providers[selectedProvider];
-  const { baseUrl, model, apiKey } = providerConfig;
-  
-  if (!apiKey) {
-    throw new Error(`API key not configured for ${selectedProvider}`);
-  }
-  
-  // Create context-aware prompt
+
+  // Build the prompt once
   let finalPrompt = prompt.replace(/X_WORD_X/g, selectedText);
-  
-  // Add context information if available
   if (context) {
     let contextInfo = "\n\nCONTEXT INFORMATION:";
-    
     if (context.fullSentence) {
       contextInfo += `\nThe word appears in this sentence: "${context.fullSentence}"`;
     }
-    
     if (context.before && context.after) {
       contextInfo += `\nSurrounding text: "...${context.before} [${selectedText}] ${context.after}..."`;
     }
-    
     contextInfo += "\n\nPlease provide a definition that is appropriate for this specific context. Consider how the word is being used in this particular situation.";
-    
     finalPrompt += contextInfo;
   }
-  
-  switch (selectedProvider) {
-    case "Together":
-      return await callTogetherAPI(finalPrompt, baseUrl, model, apiKey);
-    case "OpenRouter":
-      return await callOpenRouterAPI(finalPrompt, baseUrl, model, apiKey);
-    default:
-      throw new Error(`Unsupported provider: ${selectedProvider}`);
+
+  // Determine provider order (selected provider first, then others)
+  const providerOrder = [];
+  if (selectedProvider && providers[selectedProvider]) {
+    providerOrder.push(selectedProvider);
   }
+  for (const name of Object.keys(providers)) {
+    if (name !== selectedProvider) providerOrder.push(name);
+  }
+
+  let lastError = null;
+  for (const name of providerOrder) {
+    const config = providers[name];
+    if (!config || !config.apiKey || config.apiKey.trim() === '') {
+      lastError = new Error(`API key not configured for ${name}`);
+      continue;
+    }
+
+    try {
+      switch (name) {
+        case 'Together':
+          return await callTogetherAPI(finalPrompt, config.baseUrl, config.model, config.apiKey);
+        case 'OpenRouter':
+          return await callOpenRouterAPI(finalPrompt, config.baseUrl, config.model, config.apiKey);
+        default:
+          lastError = new Error(`Unsupported provider: ${name}`);
+      }
+    } catch (err) {
+      lastError = err;
+      console.warn(`${name} provider failed:`, err.message);
+    }
+  }
+
+  throw lastError || new Error('All providers failed');
 }
 
 

--- a/smartdefine-firefox-extension/src/content/content.js
+++ b/smartdefine-firefox-extension/src/content/content.js
@@ -41,6 +41,17 @@ function createElement(tag, attributes = {}, content = null) {
   return element;
 }
 
+// Safely set HTML using DOMParser to avoid innerHTML
+function safeSetHTML(element, htmlString) {
+  if (!element) return;
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(htmlString, 'text/html');
+  element.textContent = '';
+  parsed.body.childNodes.forEach(node => {
+    element.appendChild(node.cloneNode(true));
+  });
+}
+
 /**
  * Creates and displays a modal dialog with the LLM's formatted response.
  * @param {string} selectedText - The text the user selected.
@@ -897,11 +908,7 @@ browser.runtime.onMessage.addListener(async (message) => {
       providers: settings.providers
     });
     
-    const hasAPIKey = settings.providers && 
-                     settings.selectedProvider &&
-                     settings.providers[settings.selectedProvider] && 
-                     settings.providers[settings.selectedProvider].apiKey &&
-                     settings.providers[settings.selectedProvider].apiKey.trim().length > 0;
+    const hasAPIKey = Object.values(settings.providers || {}).some(p => p.apiKey && p.apiKey.trim().length > 0);
     
     console.log('API Key check result:', hasAPIKey);
     
@@ -915,7 +922,22 @@ browser.runtime.onMessage.addListener(async (message) => {
         // Extract context around the selected text only if enabled
         const learningSettings = settings.learningSettings || {};
         const context = learningSettings.contextAwareDefinitions ? extractContext(selectedText) : null;
-        
+
+        // Build prompt for logging
+        let finalPrompt = (settings.prompt || '').replace(/X_WORD_X/g, selectedText);
+        if (context) {
+          let contextInfo = "\n\nCONTEXT INFORMATION:";
+          if (context.fullSentence) {
+            contextInfo += `\nThe word appears in this sentence: "${context.fullSentence}"`;
+          }
+          if (context.before && context.after) {
+            contextInfo += `\nSurrounding text: "...${context.before} [${selectedText}] ${context.after}..."`;
+          }
+          contextInfo += "\n\nPlease provide a definition that is appropriate for this specific context. Consider how the word is being used in this particular situation.";
+          finalPrompt += contextInfo;
+        }
+        console.log('LLM Prompt:', finalPrompt);
+
         // Send request to background script to call LLM API with context (already has fallback)
         const response = await browser.runtime.sendMessage({
           command: "callLLMAPI",
@@ -923,6 +945,8 @@ browser.runtime.onMessage.addListener(async (message) => {
           context: context,
           settings: settings
         });
+
+        console.log('LLM Response:', response);
 
         // Update modal with the formatted response
         createResponseModal(selectedText, response, context);
@@ -938,7 +962,9 @@ browser.runtime.onMessage.addListener(async (message) => {
             command: 'callFreeDictionaryAPI',
             text: selectedText
           });
-          
+
+          console.log('Dictionary Response:', dictionaryResponse);
+
           // Update modal with dictionary response
           createResponseModal(selectedText, dictionaryResponse);
         } catch (dictError) {
@@ -961,7 +987,9 @@ browser.runtime.onMessage.addListener(async (message) => {
           command: 'callFreeDictionaryAPI',
           text: selectedText
         });
-        
+
+        console.log('Dictionary Response:', fallbackResponse);
+
         // Update modal with dictionary response
         createResponseModal(selectedText, fallbackResponse);
       } catch (dictError) {


### PR DESCRIPTION
## Summary
- add `safeSetHTML` utility
- log prompts and responses for API calls
- detect any available API key before using fallback
- choose the first configured provider with a valid key when the selected one fails

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_686064be4fe88330a669fccff6ba08ec